### PR TITLE
Separated logging subscribers to prevent duplicate log entries

### DIFF
--- a/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ImportPartExecutor.php
+++ b/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ImportPartExecutor.php
@@ -8,7 +8,6 @@ use Symfony\Component\OptionsResolver\Exception\InvalidArgumentException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use TreeHouse\IoBundle\Entity\ImportPart;
-use TreeHouse\IoBundle\EventListener\ImportLoggingSubscriber;
 use TreeHouse\IoBundle\Import\ImportFactory;
 use TreeHouse\WorkerBundle\Executor\AbstractExecutor;
 use TreeHouse\WorkerBundle\Executor\ObjectPayloadInterface;
@@ -45,8 +44,6 @@ class ImportPartExecutor extends AbstractExecutor implements ObjectPayloadInterf
         $this->doctrine = $doctrine;
         $this->importFactory = $importFactory;
         $this->logger = $logger;
-
-        $importFactory->getEventDispatcher()->addSubscriber(new ImportLoggingSubscriber($logger));
     }
 
     /**

--- a/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ScrapeUrlExecutor.php
+++ b/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ScrapeUrlExecutor.php
@@ -8,7 +8,6 @@ use Symfony\Component\OptionsResolver\Exception\InvalidArgumentException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use TreeHouse\IoBundle\Entity\Scraper as ScraperEntity;
-use TreeHouse\IoBundle\Scrape\EventListener\ScrapeLoggingSubscriber;
 use TreeHouse\IoBundle\Scrape\Exception\CrawlException;
 use TreeHouse\IoBundle\Scrape\Exception\RateLimitException;
 use TreeHouse\IoBundle\Scrape\ScraperFactory;
@@ -44,8 +43,6 @@ class ScrapeUrlExecutor extends AbstractExecutor
         $this->doctrine = $doctrine;
         $this->factory = $factory;
         $this->logger = $logger;
-
-        $this->factory->getEventDispatcher()->addSubscriber(new ScrapeLoggingSubscriber($this->logger));
     }
 
     /**

--- a/src/TreeHouse/IoBundle/EventListener/FeederLoggingSubscriber.php
+++ b/src/TreeHouse/IoBundle/EventListener/FeederLoggingSubscriber.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace TreeHouse\IoBundle\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use TreeHouse\Feeder\Event\FailedItemModificationEvent;
+use TreeHouse\Feeder\Event\ResourceEvent;
+use TreeHouse\Feeder\Event\TransportEvent;
+use TreeHouse\Feeder\FeedEvents;
+
+class FeederLoggingSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            FeedEvents::FETCH_CACHED => 'onFetchCached',
+            FeedEvents::PRE_FETCH => 'onPreFetch',
+            FeedEvents::POST_FETCH => 'onPostFetch',
+            FeedEvents::RESOURCE_START => 'onResourceStart',
+            FeedEvents::ITEM_MODIFICATION_FAILED => 'onItemModificationFailure',
+        ];
+    }
+
+    /**
+     * FeedEvents::FETCH_CACHED event.
+     */
+    public function onFetchCached()
+    {
+        $this->logger->info('Using cached feed');
+    }
+
+    /**
+     * @param TransportEvent $event
+     */
+    public function onPreFetch(TransportEvent $event)
+    {
+        $size = $event->getTransport()->getSize();
+
+        $this->logger->info(
+            sprintf(
+                'Fetching %s (%s KB)',
+                (string) $event->getTransport(),
+                $size > 0 ? number_format(round($size / 1024), 0, ',', '.') : 'unknown'
+            )
+        );
+    }
+
+    /**
+     * @param TransportEvent $event
+     */
+    public function onPostFetch(TransportEvent $event)
+    {
+        $this->logger->info(sprintf('Saved to %s', $event->getTransport()->getDestination()));
+    }
+
+    /**
+     * @param ResourceEvent $event
+     */
+    public function onResourceStart(ResourceEvent $event)
+    {
+        $this->logger->debug(sprintf(
+            'Processing resource %s (%d resources left)',
+            (string) $event->getResource()->getTransport(),
+            $event->getResources()->count()
+        ));
+    }
+
+    /**
+     * @param FailedItemModificationEvent $event
+     */
+    public function onItemModificationFailure(FailedItemModificationEvent $event)
+    {
+        $this->logger->warning($event->getException()->getMessage());
+    }
+}

--- a/src/TreeHouse/IoBundle/EventListener/ImportLoggingSubscriber.php
+++ b/src/TreeHouse/IoBundle/EventListener/ImportLoggingSubscriber.php
@@ -38,69 +38,12 @@ class ImportLoggingSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            FeedEvents::FETCH_CACHED => 'onFetchCached',
-            FeedEvents::PRE_FETCH => 'onPreFetch',
-            FeedEvents::POST_FETCH => 'onPostFetch',
-            FeedEvents::RESOURCE_START => 'onResourceStart',
-            FeedEvents::ITEM_MODIFICATION_FAILED => 'onItemModificationFailure',
             ImportEvents::ITEM_SUCCESS => 'onItemSuccess',
             ImportEvents::ITEM_FAILED => 'onItemFailed',
             ImportEvents::ITEM_SKIPPED => 'onItemSkipped',
             ImportEvents::PART_CREATED => 'onPartCreated',
             ImportEvents::EXCEPTION => 'onException',
         ];
-    }
-
-    /**
-     * FeedEvents::FETCH_CACHED event.
-     */
-    public function onFetchCached()
-    {
-        $this->logger->info('Using cached feed');
-    }
-
-    /**
-     * @param TransportEvent $event
-     */
-    public function onPreFetch(TransportEvent $event)
-    {
-        $size = $event->getTransport()->getSize();
-
-        $this->logger->info(
-            sprintf(
-                'Fetching %s (%s KB)',
-                (string) $event->getTransport(),
-                $size > 0 ? number_format(round($size / 1024), 0, ',', '.') : 'unknown'
-            )
-        );
-    }
-
-    /**
-     * @param TransportEvent $event
-     */
-    public function onPostFetch(TransportEvent $event)
-    {
-        $this->logger->info(sprintf('Saved to %s', $event->getTransport()->getDestination()));
-    }
-
-    /**
-     * @param ResourceEvent $event
-     */
-    public function onResourceStart(ResourceEvent $event)
-    {
-        $this->logger->debug(sprintf(
-            'Processing resource %s (%d resources left)',
-            (string) $event->getResource()->getTransport(),
-            $event->getResources()->count()
-        ));
-    }
-
-    /**
-     * @param FailedItemModificationEvent $event
-     */
-    public function onItemModificationFailure(FailedItemModificationEvent $event)
-    {
-        $this->logger->warning($event->getException()->getMessage());
     }
 
     /**

--- a/src/TreeHouse/IoBundle/Resources/config/services.yml
+++ b/src/TreeHouse/IoBundle/Resources/config/services.yml
@@ -4,6 +4,28 @@ services:
     class: Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher
     arguments:
       - @service_container
+    calls:
+      - [ addSubscriber, [ '@tree_house.io.subscriber.feeder_logging' ] ]
+      - [ addSubscriber, [ '@tree_house.io.subscriber.import_logging' ] ]
+      - [ addSubscriber, [ '@tree_house.io.subscriber.scrape_logging' ] ]
+
+  tree_house.io.subscriber.import_logging:
+    public: true
+    class: TreeHouse\IoBundle\EventListener\ImportLoggingSubscriber
+    arguments:
+      - @logger
+
+  tree_house.io.subscriber.feeder_logging:
+    public: true
+    class: TreeHouse\IoBundle\EventListener\FeederLoggingSubscriber
+    arguments:
+      - @logger
+
+  tree_house.io.subscriber.scrape_logging:
+    public: true
+    class: TreeHouse\IoBundle\Scrape\EventListener\ScrapeLoggingSubscriber
+    arguments:
+      - @logger
 
   tree_house.io.listener.source_modification:
     public: true

--- a/src/TreeHouse/IoBundle/Scrape/EventListener/ScrapeLoggingSubscriber.php
+++ b/src/TreeHouse/IoBundle/Scrape/EventListener/ScrapeLoggingSubscriber.php
@@ -36,7 +36,6 @@ class ScrapeLoggingSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            FeedEvents::ITEM_MODIFICATION_FAILED => 'onItemModificationFailure',
             ScraperEvents::ITEM_SUCCESS => 'onItemSuccess',
             ScraperEvents::ITEM_FAILED => 'onItemFailed',
             ScraperEvents::ITEM_SKIPPED => 'onItemSkipped',
@@ -44,14 +43,6 @@ class ScrapeLoggingSubscriber implements EventSubscriberInterface
             ScraperEvents::RATE_LIMIT_REACHED => 'onRateLimitReached',
             ScraperEvents::SCRAPE_URL_NOT_OK => 'onScrapeUrlNotOk',
         ];
-    }
-
-    /**
-     * @param FailedItemModificationEvent $event
-     */
-    public function onItemModificationFailure(FailedItemModificationEvent $event)
-    {
-        $this->logger->warning($event->getException()->getMessage());
     }
 
     /**


### PR DESCRIPTION
Both `ImportLoggingSubscriber` and `ScrapeLoggingSubscriber` were listening to `FeedEvents::ITEM_MODIFICATION_FAILED` and logging a warning for it, resulting in duplicate log entries and a degraded performance.
