### PR TITLE
Fix multiple flushes on new sources

### DIFF
--- a/src/TreeHouse/IoBundle/EventListener/SourceRawDataListener.php
+++ b/src/TreeHouse/IoBundle/EventListener/SourceRawDataListener.php
@@ -3,6 +3,7 @@
 namespace TreeHouse\IoBundle\EventListener;
 
 use TreeHouse\Feeder\Event\ResourceSerializeEvent;
+use TreeHouse\IoBundle\Import\Event\HandledItemEvent;
 use TreeHouse\IoBundle\Import\Event\SuccessItemEvent as SuccessImportItemEvent;
 use TreeHouse\IoBundle\Model\SourceInterface;
 use TreeHouse\IoBundle\Scrape\Event\SuccessItemEvent as SuccessScrapeItemEvent;
@@ -33,9 +34,9 @@ class SourceRawDataListener
     /**
      * @param SuccessImportItemEvent $e
      */
-    public function onImportItemSuccess(SuccessImportItemEvent $e)
+    public function onImportItemHandled(HandledItemEvent $e)
     {
-        $this->setRawData($e->getResult());
+        $this->setRawData($e->getSource());
     }
 
     /**
@@ -58,6 +59,7 @@ class SourceRawDataListener
     protected function setRawData(SourceInterface $source)
     {
         $source->setRawData(trim($this->rawData));
+
         $this->rawData = null;
     }
 }

--- a/src/TreeHouse/IoBundle/Import/Event/HandledItemEvent.php
+++ b/src/TreeHouse/IoBundle/Import/Event/HandledItemEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace TreeHouse\IoBundle\Import\Event;
+
+use TreeHouse\IoBundle\Import\Feed\FeedItemBag;
+use TreeHouse\IoBundle\Import\Importer\Importer;
+use TreeHouse\IoBundle\Model\SourceInterface;
+
+class HandledItemEvent extends ItemEvent
+{
+    /**
+     * @var SourceInterface
+     */
+    protected $source;
+
+    /**
+     * @param Importer        $importer
+     * @param FeedItemBag     $item
+     * @param SourceInterface $source
+     */
+    public function __construct(Importer $importer, FeedItemBag $item, SourceInterface $source)
+    {
+        parent::__construct($importer, $item);
+
+        $this->source = $source;
+    }
+
+    /**
+     * @param SourceInterface $source The result
+     */
+    public function setSource($source)
+    {
+        $this->source = $source;
+    }
+
+    /**
+     * @return SourceInterface
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
+}

--- a/src/TreeHouse/IoBundle/Import/ImportEvents.php
+++ b/src/TreeHouse/IoBundle/Import/ImportEvents.php
@@ -30,6 +30,7 @@ final class ImportEvents
     const ITEM_SUCCESS = 'io.import.item.success';
     const ITEM_FAILED = 'io.import.item.failed';
     const ITEM_SKIPPED = 'io.import.item.skipped';
+    const ITEM_HANDLED = 'io.import.item.handled';
 
     // when batch is completed
     const BATCH_PRE_COMPLETE = 'io.import.batch.pre_complete';

--- a/src/TreeHouse/IoBundle/Resources/config/services.yml
+++ b/src/TreeHouse/IoBundle/Resources/config/services.yml
@@ -42,7 +42,7 @@ services:
     class: TreeHouse\IoBundle\EventListener\SourceRawDataListener
     tags:
       - { name: tree_house.io.event_listener, event: feeder.feed.resource.serialize.pre, method: onResourcePreSerialize }
-      - { name: tree_house.io.event_listener, event: io.import.item.success, method: onImportItemSuccess }
+      - { name: tree_house.io.event_listener, event: io.import.item.handled, method: onImportItemHandled }
       - { name: tree_house.io.event_listener, event: io.scrape.item.success, method: onScrapeItemSuccess }
 
   tree_house.io.twig.extension.common:


### PR DESCRIPTION
Introduced a HandledItem event so we can adapt source with listeners without causing extra flushes, causing extra database calls and extra events on source entity.
