### PR TITLE
Remove catch all exceptions

### DIFF
--- a/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ImportPartExecutor.php
+++ b/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ImportPartExecutor.php
@@ -107,17 +107,11 @@ class ImportPartExecutor extends AbstractExecutor implements ObjectPayloadInterf
             )
         );
 
-        try {
-            $job = $this->importFactory->createImportJob($part);
-            $job->setLogger($this->logger);
-            $job->run();
+        $job = $this->importFactory->createImportJob($part);
+        $job->setLogger($this->logger);
+        $job->run();
 
-            return true;
-        } catch (\Exception $e) {
-            $this->logger->error($e->getMessage());
-
-            return false;
-        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
This makes sure exceptions are catched on a higher level (inside the worker:run command) and that failed jobs are retried.
