### PR TITLE
Fieg fix lost import directories

### DIFF
--- a/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ImportPartExecutor.php
+++ b/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ImportPartExecutor.php
@@ -107,7 +107,7 @@ class ImportPartExecutor extends AbstractExecutor implements ObjectPayloadInterf
                 $feed->getOrigin()->getTitle()
             )
         );
-        
+
         if ($import->isFinished()) {
             $this->logger->info(sprintf('Import %d has already finished', $import->getId()));
 
@@ -120,12 +120,7 @@ class ImportPartExecutor extends AbstractExecutor implements ObjectPayloadInterf
             return false;
         }
 
-        // validate that we have a valid transport config
-        try {
-            TransportFactory::createTransportFromConfig($part->getTransportConfig());
-        } catch (\RuntimeException $e) {
-            $part->setError($e->getMessage());
-
+        if (!$this->validate($part)) {
             return false;
         }
 
@@ -144,5 +139,24 @@ class ImportPartExecutor extends AbstractExecutor implements ObjectPayloadInterf
     protected function findImportPart($partId)
     {
         return $this->doctrine->getRepository('TreeHouseIoBundle:ImportPart')->find($partId);
+    }
+
+    /**
+     * @param ImportPart $part
+     *
+     * @return bool
+     */
+    protected function validate(ImportPart $part)
+    {
+        // validate that we have a valid transport config
+        try {
+            TransportFactory::createTransportFromConfig($part->getTransportConfig());
+        } catch (\RuntimeException $e) {
+            $part->setError($e->getMessage());
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ImportPartExecutor.php
+++ b/src/TreeHouse/IoBundle/Bridge/WorkerBundle/Executor/ImportPartExecutor.php
@@ -8,6 +8,7 @@ use Symfony\Component\OptionsResolver\Exception\InvalidArgumentException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use TreeHouse\IoBundle\Entity\ImportPart;
+use TreeHouse\IoBundle\Import\Feed\TransportFactory;
 use TreeHouse\IoBundle\Import\ImportFactory;
 use TreeHouse\WorkerBundle\Executor\AbstractExecutor;
 use TreeHouse\WorkerBundle\Executor\ObjectPayloadInterface;
@@ -115,6 +116,15 @@ class ImportPartExecutor extends AbstractExecutor implements ObjectPayloadInterf
 
         if ($part->isFinished()) {
             $this->logger->info(sprintf('Part %d has already finished', $part->getId()));
+
+            return false;
+        }
+
+        // validate that we have a valid transport config
+        try {
+            TransportFactory::createTransportFromConfig($part->getTransportConfig());
+        } catch (\RuntimeException $e) {
+            $part->setError($e->getMessage());
 
             return false;
         }

--- a/src/TreeHouse/IoBundle/Resources/config/import.yml
+++ b/src/TreeHouse/IoBundle/Resources/config/import.yml
@@ -14,6 +14,7 @@ services:
       - @?tree_house.io.import.item_logger
     tags:
       - { name: doctrine.event_listener, event: preRemove, lazy: true }
+      - { name: doctrine.event_listener, event: postFlush, lazy: true }
 
   tree_house.io.import.importer_builder_factory:
     public: false

--- a/tests/src/TreeHouse/IoBundle/Tests/EventListener/ImportRemovalListenerTest.php
+++ b/tests/src/TreeHouse/IoBundle/Tests/EventListener/ImportRemovalListenerTest.php
@@ -4,6 +4,7 @@ namespace TreeHouse\IoBundle\Tests\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
 use TreeHouse\IoBundle\Entity\Import;
 use TreeHouse\IoBundle\EventListener\ImportRemovalListener;
 use TreeHouse\IoBundle\Import\ImportStorage;
@@ -11,23 +12,6 @@ use TreeHouse\IoBundle\Import\Log\ItemLoggerInterface;
 
 class ImportRemovalListenerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @param Import $entity
-     *
-     * @return LifecycleEventArgs
-     */
-    public function getLifecycleEventArgs($entity)
-    {
-        /** @var \PHPUnit_Framework_MockObject_MockObject|EntityManagerInterface $manager */
-        $manager = $this
-            ->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        return new LifecycleEventArgs($entity, $manager);
-    }
-
     public function testRemoveLogOnImportRemoval()
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject|ImportStorage $storage */
@@ -51,5 +35,36 @@ class ImportRemovalListenerTest extends \PHPUnit_Framework_TestCase
         $args = $this->getLifecycleEventArgs(new Import());
 
         $listener->preRemove($args);
+        $listener->postFlush($this->getPostFlushEventArgs());
+    }
+
+    /**
+     * @param Import $entity
+     *
+     * @return LifecycleEventArgs
+     */
+    private function getLifecycleEventArgs($entity)
+    {
+        return new LifecycleEventArgs($entity, $this->createEntityManagerMock());
+    }
+
+    /**
+     * @return PostFlushEventArgs
+     */
+    private function getPostFlushEventArgs()
+    {
+        return new PostFlushEventArgs($this->createEntityManagerMock());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|EntityManagerInterface
+     */
+    private function createEntityManagerMock()
+    {
+        return $this
+            ->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock()
+            ;
     }
 }


### PR DESCRIPTION
Supersedes #30 

The issue is that we remove the files to early (preRemove). When the database transaction fails for whatever reason, files are gone, parts are still queued, workers crash due to no files.
