### PR TITLE
Fix performance source cleanup

### DIFF
--- a/src/TreeHouse/IoBundle/Command/SourceCleanupCommand.php
+++ b/src/TreeHouse/IoBundle/Command/SourceCleanupCommand.php
@@ -83,7 +83,7 @@ class SourceCleanupCommand extends Command
             function (SourceEvent $event) use ($output) {
                 $source = $event->getSource();
                 $output->writeln(
-                    sprintf('<fg=red>- %s:%s</fg>', $source->getFeed(), $source->getOriginalId())
+                    sprintf('<fg=red>- %s:%s</>', $source->getFeed(), $source->getOriginalId())
                 );
             }
         );

--- a/src/TreeHouse/IoBundle/Source/Cleaner/IdleSourceCleaner.php
+++ b/src/TreeHouse/IoBundle/Source/Cleaner/IdleSourceCleaner.php
@@ -71,6 +71,9 @@ class IdleSourceCleaner implements SourceCleanerInterface
             if (false !== $cleaned = $this->cleanFeed($cleaner, $feed, $voter, $numCleaned)) {
                 $numCleaned += $cleaned;
             }
+
+            // cleanup uow after cleaning the feed
+            $this->doctrine->getManager()->clear();
         }
 
         return $numCleaned;


### PR DESCRIPTION
In one of our projects memory usage went from 2GB to 240MB.
Performance cleaning all sources went from ~4 hours to ~5 minutes
