### PR TITLE
Finish import right away if there are no parts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 
 before_script:
   - travis_retry composer self-update
+  - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - travis_retry composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   but have moved to a different namespace. If you extended classes like `AbstractFeedTypeTest`
   or `DefaultFeedTypeTest`, you need to fix the namespaces. Also these classes
   have been renamed to `*TestCase`.
+* Imports are finished right away if there are no parts, therefor the `io:import:cleanup` 
+  command is no longer needed and should be removed as cronjob. 
+
 
 ## 1.0.4
 ### Changes

--- a/src/TreeHouse/IoBundle/Command/ImportCleanupCommand.php
+++ b/src/TreeHouse/IoBundle/Command/ImportCleanupCommand.php
@@ -7,6 +7,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @deprecated to be removed in 3.0
+ */
 class ImportCleanupCommand extends Command
 {
     /**
@@ -30,7 +33,7 @@ class ImportCleanupCommand extends Command
     protected function configure()
     {
         $this->setName('io:import:cleanup');
-        $this->setDescription('Cleans up imports that are not correct');
+        $this->setDescription('[DEPRECATED] Cleans up imports that are not correct');
     }
 
     /**

--- a/src/TreeHouse/IoBundle/Entity/ImportRepository.php
+++ b/src/TreeHouse/IoBundle/Entity/ImportRepository.php
@@ -35,6 +35,7 @@ class ImportRepository extends EntityRepository
     {
         $builder = $this->createQueryBuilder('i')
             ->andWhere('i.datetimeStarted IS NOT NULL')
+            ->andWhere('SIZE(i.parts) > 0')
             ->orderBy('i.datetimeStarted', 'DESC')
             ->setMaxResults(1)
         ;
@@ -54,6 +55,7 @@ class ImportRepository extends EntityRepository
         $builder = $this->createQueryBuilder('i')
             ->where('i.feed = :feed')
             ->andWhere('i.datetimeStarted IS NOT NULL')
+            ->andWhere('SIZE(i.parts) > 0')
             ->orderBy('i.datetimeStarted', 'DESC')
             ->setMaxResults(1)
             ->setParameter('feed', $feed)

--- a/src/TreeHouse/IoBundle/Import/ImportFactory.php
+++ b/src/TreeHouse/IoBundle/Import/ImportFactory.php
@@ -196,6 +196,12 @@ class ImportFactory implements EventSubscriberInterface
             $this->addImportParts($import);
         }
 
+        // finish import right away if we have no parts, without parts it would never be started
+        if ($import->getParts()->count() === 0) {
+            $this->getRepository()->startImport($import);
+            $this->getRepository()->finishImport($import);
+        }
+
         return $import;
     }
 

--- a/src/TreeHouse/IoBundle/Import/ImportFactory.php
+++ b/src/TreeHouse/IoBundle/Import/ImportFactory.php
@@ -198,16 +198,18 @@ class ImportFactory implements EventSubscriberInterface
             try {
                 $this->addImportParts($import);
             } catch (\Exception $e) {
+                // temporary store the exception, so we can update the import appropriately
                 $exception = $e;
             }
         }
 
         // finish import right away if we have no parts, without parts it would never be started
-        if ($import->getParts()->count() === 0) {
+        if (count($import->getParts()) === 0) {
             $this->getRepository()->startImport($import);
             $this->getRepository()->finishImport($import);
         }
 
+        // throw the exception, because catch all exceptions are evil
         if ($exception) {
             throw $exception;
         }

--- a/src/TreeHouse/IoBundle/Import/ImportScheduler.php
+++ b/src/TreeHouse/IoBundle/Import/ImportScheduler.php
@@ -140,7 +140,7 @@ class ImportScheduler
         $delta = ($cycleMinutes - $totalTime) / $importsInCycle;
         if ($diff < $delta) {
             // delta not yet passed
-            return null;
+            return [];
         }
 
         // how many should we import?


### PR DESCRIPTION
There is a `io:import:cleanup` command which removes imports without parts via a cron. This PR would make that command obsolete. Also, in our systems imports without parts would be more visible as they would be listed with all other imports and not invisibly removed by a background cron.