### PR TITLE
Set fallback time for modification date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,22 @@
-# use Docker infrastructure
-sudo: false
-
 services:
   - redis-server
 
 language: php
 php:
-  - 5.5
-  - 5.6
   - 7.0
-  - hhvm
 
 env:
-  - SYMFONY_VERSION=2.6.*
-  - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: hhvm
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 install:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
+  - bash -c 'echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'
 
 before_script:
   - travis_retry composer self-update
@@ -38,4 +28,4 @@ script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - if [[ $TRAVIS_PHP_VERSION == '5.6' ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     }
   ],
   "require": {
-    "php":                                ">=5.5",
+    "php":                                ">=7.0",
     "psr/log":                            "~1.0",
     "psr/http-message":                   "~1.0",
-    "symfony/symfony":                    "~2.6",
+    "symfony/symfony":                    "~2.8",
     "symfony/monolog-bundle":             "~2.6",
     "doctrine/orm":                       "~2.3",
     "doctrine/doctrine-bundle":           "~1.2",

--- a/src/TreeHouse/IoBundle/Import/Feed/Type/AbstractFeedType.php
+++ b/src/TreeHouse/IoBundle/Import/Feed/Type/AbstractFeedType.php
@@ -126,7 +126,15 @@ abstract class AbstractFeedType implements FeedTypeInterface
     {
         return function (ParameterBag $item) {
             if ($date = $item->get($this->getModificationDateField(), null, true)) {
-                return new \DateTime($date);
+                try {
+                    $datetime = new \DateTime($date);
+                    if ($datetime->format('H:i:s') === '00:00:00') {
+                        $datetime->setTime(23, 59, 59);
+                    }
+
+                    return $datetime;
+                } catch (\Exception $e) {
+                }
             }
 
             return null;


### PR DESCRIPTION
When a modification date is given without time, use the latest time possible to avoid an item being filtered. This happens when the feed does not specify a modification time, and an item is updated at 13:00, then modified at 15:00.

I also needed to update the library dependency and requirements to get Travis to build the build at this time. We cannot support PHP 5.5 and 5.6 anymore, nor should we. Support for Symfony 3.0 and up also cannot work without fixing the dependency on the `ParameterBag`, of which we ue the `$deep` requirement which got dropped in Symfony 3.0.

In any case, this library is abandoned as a whole and we should indicate it as such.