### PR TITLE
Use Imported date instead of modified date

### DIFF
--- a/src/TreeHouse/IoBundle/Import/Handler/DoctrineHandler.php
+++ b/src/TreeHouse/IoBundle/Import/Handler/DoctrineHandler.php
@@ -2,6 +2,7 @@
 
 namespace TreeHouse\IoBundle\Import\Handler;
 
+use DateTime;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use TreeHouse\IoBundle\Exception\ValidationException;
 use TreeHouse\IoBundle\Import\Exception\FailedItemException;
@@ -46,6 +47,7 @@ class DoctrineHandler implements HandlerInterface
         // save data
         $source->setData($item->all());
         $source->setOriginalUrl($item->getOriginalUrl());
+        $source->setDatetimeImported(new DateTime());
 
         try {
             $this->validate($source);

--- a/src/TreeHouse/IoBundle/Item/Modifier/Item/Filter/ModifiedItemFilter.php
+++ b/src/TreeHouse/IoBundle/Item/Modifier/Item/Filter/ModifiedItemFilter.php
@@ -2,7 +2,6 @@
 
 namespace TreeHouse\IoBundle\Item\Modifier\Item\Filter;
 
-use DateTime;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use TreeHouse\Feeder\Exception\FilterException;
 use TreeHouse\Feeder\Modifier\Item\Filter\FilterInterface;
@@ -50,7 +49,6 @@ class ModifiedItemFilter implements FilterInterface
                 throw new FilterException('Item is not modified');
             }
         }
-        $source->setDatetimeImported(new DateTime());
 
         // item is modified or we don't have enough information to determine that, either way continue.
     }

--- a/src/TreeHouse/IoBundle/Item/Modifier/Item/Filter/ModifiedItemFilter.php
+++ b/src/TreeHouse/IoBundle/Item/Modifier/Item/Filter/ModifiedItemFilter.php
@@ -2,6 +2,7 @@
 
 namespace TreeHouse\IoBundle\Item\Modifier\Item\Filter;
 
+use DateTime;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use TreeHouse\Feeder\Exception\FilterException;
 use TreeHouse\Feeder\Modifier\Item\Filter\FilterInterface;
@@ -45,10 +46,11 @@ class ModifiedItemFilter implements FilterInterface
 
         // first try modification date
         if (null !== $mutationDate = $item->getDatetimeModified()) {
-            if ($source->getDatetimeModified() > $mutationDate) {
+            if ($source->getDatetimeImported() > $mutationDate) {
                 throw new FilterException('Item is not modified');
             }
         }
+        $source->setDatetimeImported(new DateTime());
 
         // item is modified or we don't have enough information to determine that, either way continue.
     }

--- a/src/TreeHouse/IoBundle/Model/SourceInterface.php
+++ b/src/TreeHouse/IoBundle/Model/SourceInterface.php
@@ -182,6 +182,22 @@ interface SourceInterface
     public function getDatetimeModified();
 
     /**
+     * Set datetimeImported.
+     *
+     * @param \DateTime $datetimeImported
+     *
+     * @return $this
+     */
+    public function setDatetimeImported(\DateTime $datetimeImported);
+
+    /**
+     * Get datetimeImported.
+     *
+     * @return \DateTime
+     */
+    public function getDatetimeImported();
+
+    /**
      * Set datetimeLastVisited.
      *
      * @param \DateTime $datetimeLastVisited

--- a/src/TreeHouse/IoBundle/Test/Mock/SourceMock.php
+++ b/src/TreeHouse/IoBundle/Test/Mock/SourceMock.php
@@ -60,6 +60,11 @@ class SourceMock implements SourceInterface
     protected $datetimeModified;
 
     /**
+     * @var \DateTime
+     */
+    protected $datetimeImported;
+
+    /**
      * @var OriginInterface
      */
     protected $origin;
@@ -252,6 +257,29 @@ class SourceMock implements SourceInterface
     public function getDatetimeModified()
     {
         return $this->datetimeModified;
+    }
+
+    /**
+     * Set datetimeImported.
+     *
+     * @param \DateTime $datetimeImported
+     *
+     * @return $this
+     */
+    public function setDatetimeImported(\DateTime $datetimeImported)
+    {
+        $this->datetimeImported = $datetimeImported;
+        return $this;
+    }
+
+    /**
+     * Get datetimeImported.
+     *
+     * @return \DateTime
+     */
+    public function getDatetimeImported()
+    {
+        return $this->datetimeImported;
     }
 
     /**

--- a/tests/src/TreeHouse/IoBundle/Tests/Item/Modifier/Item/Filter/ModifiedItemFilterTest.php
+++ b/tests/src/TreeHouse/IoBundle/Tests/Item/Modifier/Item/Filter/ModifiedItemFilterTest.php
@@ -45,7 +45,7 @@ class ModifiedItemFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function testUnmodifiedItems(\DateTime $sourceDate, \DateTime $itemDate = null)
     {
-        $this->source->setDatetimeModified($sourceDate);
+        $this->source->setDatetimeImported($sourceDate);
         $item = new FeedItemBag(new FeedMock(1234), '123abc');
         $item->setDatetimeModified($itemDate);
 
@@ -65,7 +65,7 @@ class ModifiedItemFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function testModifiedItems(\DateTime $sourceDate, \DateTime $itemDate = null)
     {
-        $this->source->setDatetimeModified($sourceDate);
+        $this->source->setDatetimeImported($sourceDate);
         $item = new FeedItemBag(new FeedMock(1234), '123abc');
         $item->setDatetimeModified($itemDate);
 

--- a/tests/src/TreeHouse/IoBundle/Tests/Scrape/ScraperTest.php
+++ b/tests/src/TreeHouse/IoBundle/Tests/Scrape/ScraperTest.php
@@ -2,6 +2,7 @@
 
 namespace TreeHouse\IoBundle\Tests\Scrape;
 
+use DateTime;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use TreeHouse\Feeder\Exception\FilterException;
@@ -187,7 +188,7 @@ class ScraperTest extends \PHPUnit_Framework_TestCase
         $this->crawler
             ->expects($this->once())
             ->method('crawl')
-            ->will($this->throwException(new RateLimitException('http://example.org', '', new \DateTime())))
+            ->will($this->throwException(new RateLimitException('http://example.org', '', new DateTime('+3 seconds'))))
         ;
 
         $this->scraper->scrape(new ScraperEntity(), 'http://example.org');
@@ -259,7 +260,7 @@ class ScraperTest extends \PHPUnit_Framework_TestCase
             ->method('dispatch')
             ->with(ScraperEvents::SCRAPE_NEXT_URL, $this->isInstanceOf(ScrapeUrlEvent::class));
 
-        $this->scraper->scrapeAfter(new ScraperEntity(), 'http://example.org', new \DateTime());
+        $this->scraper->scrapeAfter(new ScraperEntity(), 'http://example.org', new DateTime());
     }
 
     public function testScrapeNext()
@@ -312,7 +313,7 @@ class ScraperTest extends \PHPUnit_Framework_TestCase
         $scraper
             ->expects($this->once())
             ->method('scrapeAfter')
-            ->with($entity, $url, $this->greaterThanOrEqual(new \DateTime()))
+            ->with($entity, $url, $this->greaterThanOrEqual(new DateTime()))
         ;
 
         $scraper->setAsync(true);

--- a/tests/src/TreeHouse/IoIntegrationBundle/Entity/Source.php
+++ b/tests/src/TreeHouse/IoIntegrationBundle/Entity/Source.php
@@ -107,6 +107,13 @@ class Source implements SourceInterface
      *
      * @ORM\Column(type="datetime")
      */
+    protected $datetimeImported;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(type="datetime")
+     */
     protected $datetimeLastVisited;
 
     /**
@@ -328,6 +335,29 @@ class Source implements SourceInterface
         $this->datetimeModified = $datetimeModified;
 
         return $this;
+    }
+
+    /**
+     * Set datetimeImported.
+     *
+     * @param \DateTime $datetimeImported
+     *
+     * @return $this
+     */
+    public function setDatetimeImported(\DateTime $datetimeImported)
+    {
+        $this->datetimeImported = $datetimeImported;
+        return $this;
+    }
+
+    /**
+     * Get datetimeImported.
+     *
+     * @return \DateTime
+     */
+    public function getDatetimeImported()
+    {
+        return $this->datetimeImported;
     }
 
     /**

--- a/tests/src/TreeHouse/IoIntegrationBundle/Source/SourceManager.php
+++ b/tests/src/TreeHouse/IoIntegrationBundle/Source/SourceManager.php
@@ -2,6 +2,7 @@
 
 namespace TreeHouse\IoIntegrationBundle\Source;
 
+use DateTime;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use TreeHouse\IoBundle\Entity\Feed;
 use TreeHouse\IoBundle\Entity\Scraper;
@@ -68,8 +69,9 @@ class SourceManager implements SourceManagerInterface
         $source->setOriginalId($originalId);
         $source->setOriginalUrl($originalUrl);
         $source->setBlocked(false);
-        $source->setDatetimeLastVisited(new \DateTime());
-        $source->setDatetimeModified(new \DateTime());
+        $source->setDatetimeLastVisited(new DateTime());
+        $source->setDatetimeModified(new DateTime());
+        $source->setDatetimeImported(new DateTime());
 
         return $source;
     }
@@ -88,8 +90,9 @@ class SourceManager implements SourceManagerInterface
         $source->setOriginalId($originalId);
         $source->setOriginalUrl($originalUrl);
         $source->setBlocked(false);
-        $source->setDatetimeLastVisited(new \DateTime());
-        $source->setDatetimeModified(new \DateTime());
+        $source->setDatetimeLastVisited(new DateTime());
+        $source->setDatetimeModified(new DateTime());
+        $source->setDatetimeImported(new DateTime());
 
         return $source;
     }


### PR DESCRIPTION
We ran into situations where feeds didn't get imported because the "modified date" was after the import date. The modified date might get altered for different reasons. So now we have a separate import date column to verify that the import is newer then the previous one.